### PR TITLE
Fix mobile overlay scroll

### DIFF
--- a/3dchess20.html
+++ b/3dchess20.html
@@ -75,6 +75,7 @@
         z-index: 10;
         text-align: center;
         padding: 20px;
+        overflow-y: auto;
       }
       #setup-overlay h1 {
         margin-bottom: 15px;

--- a/refactored/css/styles.css
+++ b/refactored/css/styles.css
@@ -65,6 +65,7 @@ body {
   z-index: 10;
   text-align: center;
   padding: 20px;
+  overflow-y: auto;
 }
 #setup-overlay h1 {
   margin-bottom: 15px;


### PR DESCRIPTION
## Summary
- make setup overlay scrollable on small screens

## Validation
- `node -e "const fs=require('fs');fs.readFile('3dchess20.html','utf8',(e,d)=>console.log('HTML length',d.length))"`
- `node -e "const fs=require('fs');fs.readFile('refactored/index.html','utf8',(e,d)=>console.log('index.html length',d.length))"`