### PR TITLE
Improve setup overlay contrast and lighter scene background

### DIFF
--- a/3dchess20.html
+++ b/3dchess20.html
@@ -70,7 +70,8 @@
         width: 100vw;
         min-height: 100vh;
 
-        background-color: rgba(173, 216, 230, 0.95);
+        /* Dark overlay for better contrast */
+        background-color: rgba(0, 0, 0, 0.9);
 
         display: flex;
         flex-direction: column;
@@ -793,7 +794,8 @@
       }
       function setupScene() {
         scene = new THREE.Scene();
-        scene.background = new THREE.Color(0x000000);
+        // Use a light background for better visibility
+        scene.background = new THREE.Color(0xf0f0f0);
         camera = new THREE.PerspectiveCamera(
           60,
           window.innerWidth / window.innerHeight,

--- a/refactored/css/styles.css
+++ b/refactored/css/styles.css
@@ -60,7 +60,8 @@ body {
   width: 100vw;
   min-height: 100vh;
 
-  background-color: rgba(173, 216, 230, 0.95);
+  /* Dark overlay for better contrast */
+  background-color: rgba(0, 0, 0, 0.9);
 
   display: flex;
   flex-direction: column;

--- a/refactored/js/game.js
+++ b/refactored/js/game.js
@@ -445,7 +445,8 @@ function playSound(type) {
 }
 function setupScene() {
   scene = new THREE.Scene();
-  scene.background = new THREE.Color(0x000000);
+  // Use a light background for better visibility
+  scene.background = new THREE.Color(0xf0f0f0);
   camera = new THREE.PerspectiveCamera(
     60,
     window.innerWidth / window.innerHeight,


### PR DESCRIPTION
## Summary
- darken setup overlay for better contrast
- use lighter scene background in both game versions

## Validation
- `ls -l 3dchess20.html refactored/index.html`