### PR TITLE
Adjust overlay height for mobile

### DIFF
--- a/3dchess20.html
+++ b/3dchess20.html
@@ -69,7 +69,7 @@
         left: 0;
         width: 100vw;
         min-height: 100vh;
-        height: 100vh;
+        height: auto;
 
         /* Dark overlay for better contrast */
         background-color: rgba(0, 0, 0, 0.9);
@@ -81,6 +81,7 @@
         z-index: 10;
         text-align: center;
         padding: 20px;
+        padding-bottom: calc(60px + env(safe-area-inset-bottom, 0px));
         overflow-y: auto;
         touch-action: auto;
       }
@@ -91,9 +92,9 @@
         }
       }
       @supports (height: 100dvh) {
-        #setup-overlay {
-          height: 100dvh;
-        }
+          #setup-overlay {
+            min-height: 100dvh;
+          }
       }
       #setup-overlay h1 {
         margin-bottom: 15px;

--- a/refactored/css/styles.css
+++ b/refactored/css/styles.css
@@ -59,7 +59,7 @@ body {
   left: 0;
   width: 100vw;
   min-height: 100vh;
-  height: 100vh;
+  height: auto;
 
   /* Dark overlay for better contrast */
   background-color: rgba(0, 0, 0, 0.9);
@@ -71,6 +71,7 @@ body {
   z-index: 10;
   text-align: center;
   padding: 20px;
+  padding-bottom: calc(60px + env(safe-area-inset-bottom, 0px));
   overflow-y: auto;
   touch-action: auto;
 }
@@ -83,7 +84,7 @@ body {
 }
 @supports (height: 100dvh) {
   #setup-overlay {
-    height: 100dvh;
+    min-height: 100dvh;
   }
 }
 #setup-overlay h1 {


### PR DESCRIPTION
## Summary
- fix `#setup-overlay` height handling on mobile
- ensure sticky start button stays visible by adding bottom padding

## Testing
- `xdg-open 3dchess20.html` *(fails: command not found)*