### PR TITLE
Add color specific threatening materials

### DIFF
--- a/3dchess20.html
+++ b/3dchess20.html
@@ -496,6 +496,20 @@
           roughness: 0.6,
           metalness: 0.1,
         }),
+        PIECE_STATE_THREATENING_WHITE: new THREE.MeshStandardMaterial({
+          color: 0x8888ff,
+          emissive: 0x6666ee,
+          emissiveIntensity: 0.5,
+          roughness: 0.6,
+          metalness: 0.1,
+        }),
+        PIECE_STATE_THREATENING_BLACK: new THREE.MeshStandardMaterial({
+          color: 0x6666dd,
+          emissive: 0x4444aa,
+          emissiveIntensity: 0.5,
+          roughness: 0.6,
+          metalness: 0.1,
+        }),
         CONFLICT_RAY_WHITE_ATTACKING: new THREE.MeshBasicMaterial({
           color: 0xff8800,
           transparent: true,
@@ -1673,7 +1687,11 @@
           isOv = true;
         } else if (pUD.isThreatening) {
           storeOrig(mOG);
-          tBM = MATERIALS.PIECE_STATE_THREATENING.clone();
+          tBM = (
+            pC === COLORS.WHITE
+              ? MATERIALS.PIECE_STATE_THREATENING_WHITE
+              : MATERIALS.PIECE_STATE_THREATENING_BLACK
+          ).clone();
           isOv = true;
         } else {
           if (pUD.originalMaterial) {

--- a/refactored/js/game.js
+++ b/refactored/js/game.js
@@ -130,6 +130,20 @@ const MATERIALS = {
     roughness: 0.6,
     metalness: 0.1,
   }),
+  PIECE_STATE_THREATENING_WHITE: new THREE.MeshStandardMaterial({
+    color: 0x8888ff,
+    emissive: 0x6666ee,
+    emissiveIntensity: 0.5,
+    roughness: 0.6,
+    metalness: 0.1,
+  }),
+  PIECE_STATE_THREATENING_BLACK: new THREE.MeshStandardMaterial({
+    color: 0x6666dd,
+    emissive: 0x4444aa,
+    emissiveIntensity: 0.5,
+    roughness: 0.6,
+    metalness: 0.1,
+  }),
   CONFLICT_RAY_WHITE_ATTACKING: new THREE.MeshBasicMaterial({
     color: 0xff8800,
     transparent: true,
@@ -1269,7 +1283,11 @@ function applyPieceVisuals(mOG) {
     isOv = true;
   } else if (pUD.isThreatening) {
     storeOrig(mOG);
-    tBM = MATERIALS.PIECE_STATE_THREATENING.clone();
+    tBM = (
+      pC === COLORS.WHITE
+        ? MATERIALS.PIECE_STATE_THREATENING_WHITE
+        : MATERIALS.PIECE_STATE_THREATENING_BLACK
+    ).clone();
     isOv = true;
   } else {
     if (pUD.originalMaterial) {


### PR DESCRIPTION
## Summary
- add new materials `PIECE_STATE_THREATENING_WHITE` and `PIECE_STATE_THREATENING_BLACK`
- apply color specific materials when a piece is threatening

## Validation
- `node --check refactored/js/game.js`
