### PR TITLE
Add starship image option

### DIFF
--- a/3dchess20.html
+++ b/3dchess20.html
@@ -378,6 +378,14 @@
           />
           <label for="show-move-log">Show Move Log</label>
         </div>
+        <div style="margin-top: 5px">
+          <input
+            type="checkbox"
+            id="use-themed-images"
+            name="use-themed-images"
+          />
+          <label for="use-themed-images">Use Starship Images</label>
+        </div>
       </div>
       <button id="start-game-button">Start Game</button>
     </div>
@@ -587,6 +595,22 @@
       const CAPTURED_SCALE = 0.5;
       const CAPTURED_SPACING = VOXEL_SIZE * (CAPTURED_SCALE + 0.2);
       const AI_DELAY = 500;
+      const STARSHIP_PROMPTS = {
+        [PIECE_TYPES.PAWN]:
+          "A small agile starfighter, sleek silver body with blue engine glow, resting on a flat maintenance pad under bright hangar lighting",
+        [PIECE_TYPES.ROOK]:
+          "A sturdy defensive turret, square base with armored plating, gun barrels pointing upward, illuminated by spotlights in a space station bay",
+        [PIECE_TYPES.KNIGHT]:
+          "A nimble interceptor spacecraft with swept wings and forward cockpit, matte gray hull with red trim, parked on a landing deck at dusk",
+        [PIECE_TYPES.BISHOP]:
+          "A long-range patrol cruiser with elongated body and twin engine nacelles, dark metallic finish with subtle green highlights, floating in open space",
+        [PIECE_TYPES.QUEEN]:
+          "A formidable command ship, wide hull with layered armor and glowing blue thrusters, featuring sleek antenna arrays, showcased under studio lighting",
+        [PIECE_TYPES.KING]:
+          "A massive capital ship, commanding bridge tower atop a reinforced hull, silver and gold accents, hovering above a space dock bathed in soft ambient light",
+      };
+      let pieceTextures = {};
+      let pieceSpritesByType = {};
 
       let scene,
         camera,
@@ -608,6 +632,7 @@
           lastMove: null,
           moveHistory: [],
           showMoveLog: true,
+          themedImages: false,
           kingPositions: { [COLORS.WHITE]: null, [COLORS.BLACK]: null },
         selectedSetupType: "low",
         upAxis: "y",
@@ -659,6 +684,8 @@
           document.getElementById("show-conflict-rays").checked;
         gameState.showMoveLog =
           document.getElementById("show-move-log").checked;
+        gameState.themedImages =
+          document.getElementById("use-themed-images").checked;
         const mhInput = document.getElementById("max-height-input");
         let hVal = parseInt(mhInput.value, 10);
         if (isNaN(hVal) || hVal < 2 || hVal > 8) {
@@ -680,6 +707,7 @@
             helvetikerFont = font;
             setupInitialPieces();
             setupPieceMeshes();
+            if (gameState.themedImages) loadPieceTextures();
             setupAxisLabels();
             try {
               if (typeof THREE.OrbitControls === "undefined") {
@@ -728,6 +756,7 @@
             console.error("Font load failed:", err);
             setupInitialPieces();
             setupPieceMeshes();
+            if (gameState.themedImages) loadPieceTextures();
             try {
               if (typeof THREE.OrbitControls === "undefined") {
                 throw new Error("OrbitControls script not loaded.");
@@ -790,6 +819,15 @@
           confRaysCb.addEventListener("change", (e) => {
             gameState.showConflictRays = e.target.checked;
             drawConflictRays();
+          });
+        }
+        const themeCb = document.getElementById("use-themed-images");
+        if (themeCb) {
+          themeCb.checked = gameState.themedImages;
+          themeCb.addEventListener("change", (e) => {
+            gameState.themedImages = e.target.checked;
+            if (gameState.themedImages) loadPieceTextures();
+            else clearPieceTextures();
           });
         }
       }
@@ -1464,6 +1502,19 @@
           finalObject.add(borderMesh);
           finalObject.add(textMesh);
         }
+        if (gameState.themedImages) {
+          const spriteMaterial = new THREE.SpriteMaterial({ color: 0xffffff });
+          const sprite = new THREE.Sprite(spriteMaterial);
+          sprite.scale.set(VOXEL_SIZE, VOXEL_SIZE, 1);
+          sprite.position.set(0, VOXEL_SIZE * scale, 0);
+          finalObject.add(sprite);
+          if (!pieceSpritesByType[type]) pieceSpritesByType[type] = [];
+          pieceSpritesByType[type].push(sprite);
+          if (pieceTextures[type]) {
+            sprite.material.map = pieceTextures[type];
+            sprite.material.needsUpdate = true;
+          }
+        }
         switch (gameState.upAxis) {
           case "x":
             finalObject.rotation.set(0, 0, -Math.PI / 2);
@@ -1538,6 +1589,32 @@
               z: Math.floor(wP.y / VOXEL_SIZE + hH),
             };
         }
+      }
+      function loadPieceTextures() {
+        const loader = new THREE.TextureLoader();
+        Object.keys(STARSHIP_PROMPTS).forEach((type) => {
+          const url =
+            "https://image.pollinations.ai/prompt/" +
+            encodeURIComponent(STARSHIP_PROMPTS[type]);
+          loader.load(url, (texture) => {
+            pieceTextures[type] = texture;
+            const sprites = pieceSpritesByType[type] || [];
+            sprites.forEach((s) => {
+              s.material.map = texture;
+              s.material.needsUpdate = true;
+              s.visible = true;
+            });
+          });
+        });
+      }
+      function clearPieceTextures() {
+        Object.values(pieceSpritesByType).forEach((sprites) => {
+          sprites.forEach((s) => {
+            s.material.map = null;
+            s.material.needsUpdate = true;
+            s.visible = false;
+          });
+        });
       }
       function isValidCoordinate(x, y, z) {
         return (

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ This project implements a chess variant played on an 8x8xN grid within a 3D cube
 *   **Board Height:** Sets the maximum coordinate value (exclusive) along the chosen "UP" axis (range 2-8). An 8x8x4 board would have `maxHeight = 4`.
 *   **Opponent:** Choose between playing against another human or a basic AI (Random or Greedy). AI currently plays Black.
 *   **Highlight Captures:** If checked, squares where a capture is possible will use a distinct red highlight marker.
+*   **Use Starship Images:** When enabled, piece sprites are loaded from the Pollinations service using the space-themed prompts in `docs/starship-theme-prompts.md`.
 
 ## Rules Summary (Variant)
 

--- a/refactored/index.html
+++ b/refactored/index.html
@@ -136,6 +136,14 @@
           />
           <label for="show-move-log">Show Move Log</label>
         </div>
+        <div style="margin-top: 5px">
+          <input
+            type="checkbox"
+            id="use-themed-images"
+            name="use-themed-images"
+          />
+          <label for="use-themed-images">Use Starship Images</label>
+        </div>
       </div>
       <button id="start-game-button">Start Game</button>
     </div>


### PR DESCRIPTION
## Summary
- allow space-themed piece images via Pollinations
- add toggle in setup overlay to turn starship images on/off
- load images for pieces using prompts from `docs/starship-theme-prompts.md`
- document new option

## Validation
- `node -e "require('fs').readFileSync('3dchess20.html');console.log('read ok')"`
- `xdg-open 3dchess20.html` *(fails: no display)*