### PR TITLE
Map starship textures onto meshes and add pilot portraits

### DIFF
--- a/3dchess20.html
+++ b/3dchess20.html
@@ -609,8 +609,23 @@
         [PIECE_TYPES.KING]:
           "A massive capital ship, commanding bridge tower atop a reinforced hull, silver and gold accents, hovering above a space dock bathed in soft ambient light",
       };
+      const PILOT_PROMPTS = {
+        [PIECE_TYPES.PAWN]:
+          "A young starfighter cadet with visor helmet and hopeful smile, blue flight suit, digital painting",
+        [PIECE_TYPES.ROOK]:
+          "A stern garrison commander in heavy armor, square jaw, dark grey uniform, cinematic lighting",
+        [PIECE_TYPES.KNIGHT]:
+          "A daring interceptor pilot with a confident grin, red-trimmed suit, windswept hair",
+        [PIECE_TYPES.BISHOP]:
+          "A calm tactical officer with subtle cybernetic implants and long coat, cool green tones",
+        [PIECE_TYPES.QUEEN]:
+          "A regal ace pilot with poised expression, gold‑trimmed suit, soft studio glow",
+        [PIECE_TYPES.KING]:
+          "A seasoned admiral with scars and authoritative gaze, decorated uniform, dramatic lighting",
+      };
       let pieceTextures = {};
-      let pieceSpritesByType = {};
+      let pilotTextures = {};
+      let pilotSpritesByType = {};
 
       let scene,
         camera,
@@ -707,7 +722,10 @@
             helvetikerFont = font;
             setupInitialPieces();
             setupPieceMeshes();
-            if (gameState.themedImages) loadPieceTextures();
+            if (gameState.themedImages) {
+              loadPieceTextures();
+              loadPilotTextures();
+            }
             setupAxisLabels();
             try {
               if (typeof THREE.OrbitControls === "undefined") {
@@ -756,7 +774,10 @@
             console.error("Font load failed:", err);
             setupInitialPieces();
             setupPieceMeshes();
-            if (gameState.themedImages) loadPieceTextures();
+            if (gameState.themedImages) {
+              loadPieceTextures();
+              loadPilotTextures();
+            }
             try {
               if (typeof THREE.OrbitControls === "undefined") {
                 throw new Error("OrbitControls script not loaded.");
@@ -826,8 +847,12 @@
           themeCb.checked = gameState.themedImages;
           themeCb.addEventListener("change", (e) => {
             gameState.themedImages = e.target.checked;
-            if (gameState.themedImages) loadPieceTextures();
-            else clearPieceTextures();
+            if (gameState.themedImages) {
+              loadPieceTextures();
+              loadPilotTextures();
+            } else {
+              clearPieceTextures();
+            }
           });
         }
       }
@@ -1455,6 +1480,18 @@
         }
         let finalObject = new THREE.Group();
         finalObject.add(baseMesh);
+        finalObject.userData.baseMesh = baseMesh;
+        if (gameState.themedImages && pieceTextures[type]) {
+          const applyTex = (o) => {
+            if (o instanceof THREE.Mesh && !(o.geometry instanceof THREE.TextGeometry)) {
+              o.material.map = pieceTextures[type];
+              o.material.needsUpdate = true;
+            } else if (o instanceof THREE.Group) {
+              o.children.forEach((c) => applyTex(c));
+            }
+          };
+          applyTex(baseMesh);
+        }
         if (royalBaseMesh) finalObject.add(royalBaseMesh);
         if (helvetikerFont && pieceLabel !== "?") {
           const textGeo = new THREE.TextGeometry(pieceLabel, {
@@ -1507,13 +1544,15 @@
           const sprite = new THREE.Sprite(spriteMaterial);
           sprite.scale.set(VOXEL_SIZE, VOXEL_SIZE, 1);
           sprite.position.set(0, VOXEL_SIZE * scale, 0);
+          sprite.visible = false;
           finalObject.add(sprite);
-          if (!pieceSpritesByType[type]) pieceSpritesByType[type] = [];
-          pieceSpritesByType[type].push(sprite);
-          if (pieceTextures[type]) {
-            sprite.material.map = pieceTextures[type];
+          if (!pilotSpritesByType[type]) pilotSpritesByType[type] = [];
+          pilotSpritesByType[type].push(sprite);
+          if (pilotTextures[type]) {
+            sprite.material.map = pilotTextures[type];
             sprite.material.needsUpdate = true;
           }
+          finalObject.userData.faceSprite = sprite;
         }
         switch (gameState.upAxis) {
           case "x":
@@ -1598,23 +1637,69 @@
             encodeURIComponent(STARSHIP_PROMPTS[type]);
           loader.load(url, (texture) => {
             pieceTextures[type] = texture;
-            const sprites = pieceSpritesByType[type] || [];
+            pieceMeshes.forEach((m) => {
+              if (m.userData && m.userData.type === parseInt(type)) {
+                const base = m.userData.baseMesh;
+                const applyTex = (o) => {
+                  if (
+                    o instanceof THREE.Mesh &&
+                    !(o.geometry instanceof THREE.TextGeometry)
+                  ) {
+                    o.material.map = texture;
+                    o.material.needsUpdate = true;
+                  } else if (o instanceof THREE.Group) {
+                    o.children.forEach((c) => applyTex(c));
+                  }
+                };
+                if (base) applyTex(base);
+              }
+            });
+          });
+        });
+      }
+      function loadPilotTextures() {
+        const loader = new THREE.TextureLoader();
+        Object.keys(PILOT_PROMPTS).forEach((type) => {
+          const url =
+            "https://image.pollinations.ai/prompt/" +
+            encodeURIComponent(PILOT_PROMPTS[type]);
+          loader.load(url, (texture) => {
+            pilotTextures[type] = texture;
+            const sprites = pilotSpritesByType[type] || [];
             sprites.forEach((s) => {
               s.material.map = texture;
               s.material.needsUpdate = true;
-              s.visible = true;
             });
           });
         });
       }
       function clearPieceTextures() {
-        Object.values(pieceSpritesByType).forEach((sprites) => {
+        pieceMeshes.forEach((m) => {
+          const base = m.userData.baseMesh;
+          if (base) {
+            const clearMap = (o) => {
+              if (
+                o instanceof THREE.Mesh &&
+                !(o.geometry instanceof THREE.TextGeometry)
+              ) {
+                o.material.map = null;
+                o.material.needsUpdate = true;
+              } else if (o instanceof THREE.Group) {
+                o.children.forEach((c) => clearMap(c));
+              }
+            };
+            clearMap(base);
+          }
+        });
+        Object.values(pilotSpritesByType).forEach((sprites) => {
           sprites.forEach((s) => {
             s.material.map = null;
             s.material.needsUpdate = true;
             s.visible = false;
           });
         });
+        pieceTextures = {};
+        pilotTextures = {};
       }
       function isValidCoordinate(x, y, z) {
         return (
@@ -1921,6 +2006,14 @@
           }
         };
         applyMat(mOG, tBM, tBsM);
+        if (pUD.faceSprite) {
+          if (pilotTextures[pI.type]) {
+            pUD.faceSprite.material.map = pilotTextures[pI.type];
+            pUD.faceSprite.material.needsUpdate = true;
+          }
+          pUD.faceSprite.visible =
+            iCSel || pUD.isUnderAttack || pUD.isThreatening;
+        }
       }
       function updateAllPieceTacticalVisuals() {
         if (!boardState || pieceMeshes.length === 0) return;

--- a/docs/pilot-character-prompts.md
+++ b/docs/pilot-character-prompts.md
@@ -1,0 +1,30 @@
+# Pilot Character Portrait Prompts
+
+Use these prompts with image generators like Pollinations to create stylized pilot faces for the in-game panels.
+
+## General Guidance
+
+- Bust or shoulders-up view facing forward.
+- Consistent semi-realistic digital painting style.
+- Futuristic flight suits or uniforms with subtle sci-fi touches.
+- Transparent or plain dark background works best.
+
+## Piece Prompts
+
+### Pawn
+"A young starfighter cadet with visor helmet and hopeful smile, blue pilot suit, digital painting"
+
+### Rook
+"A stern garrison commander in heavy armor, square jaw, dark grey uniform, cinematic lighting"
+
+### Knight
+"A daring interceptor pilot with a confident grin, windswept hair, red-trimmed flight suit"
+
+### Bishop
+"A calm tactical officer with subtle cybernetic implants and a long dark coat, cool green lighting"
+
+### Queen
+"A regal ace pilot with poised expression, ornate gold-trimmed suit, soft studio glow"
+
+### King
+"A seasoned admiral with scars and authoritative gaze, decorated uniform, dramatic shadows"


### PR DESCRIPTION
## Summary
- starship textures now map directly onto piece meshes
- pilot portrait sprites are shown when a piece is selected or in danger
- add prompts for generating pilot portraits

## Validation
- `node --check refactored/js/game.js`
