### PR TITLE
Add meta scoring system

### DIFF
--- a/3dchess20.html
+++ b/3dchess20.html
@@ -396,6 +396,8 @@
       <div><span id="turn-label">Turn:</span> <span id="turn">White</span></div>
       <div>White Material: <span id="white-score">0</span></div>
       <div>Black Material: <span id="black-score">0</span></div>
+      <div>White Meta: <span id="white-meta">0</span></div>
+      <div>Black Meta: <span id="black-meta">0</span></div>
       <div>Status: <span id="status">Waiting...</span></div>
     </div>
     <div id="move-log"></div>
@@ -596,6 +598,7 @@
       const CAPTURED_SCALE = 0.5;
       const CAPTURED_SPACING = VOXEL_SIZE * (CAPTURED_SCALE + 0.2);
       const AI_DELAY = 500;
+      const CHECK_REWARD = 1;
       const STARSHIP_IMAGES = {
         [PIECE_TYPES.PAWN]: "assets/starship/pieces/P.svg",
         [PIECE_TYPES.ROOK]: "assets/starship/pieces/R.svg",
@@ -657,6 +660,8 @@
       let capturedByBlack = [];
       let whiteScore = 0;
       let blackScore = 0;
+      let whiteMeta = 0;
+      let blackMeta = 0;
       let capturedWhiteDisplayMeshes = [];
       let capturedBlackDisplayMeshes = [];
       let selectedPiece = null;
@@ -1082,6 +1087,8 @@
         capturedByBlack = [];
         whiteScore = 0;
         blackScore = 0;
+        whiteMeta = 0;
+        blackMeta = 0;
         capturedWhiteDisplayMeshes.forEach((m) => scene.remove(m));
         capturedBlackDisplayMeshes.forEach((m) => scene.remove(m));
         capturedWhiteDisplayMeshes = [];
@@ -2638,9 +2645,11 @@
         const pV = PIECE_VALUES[cPD.type] || 0;
         if (cP === COLORS.WHITE) {
           whiteScore += pV;
+          whiteMeta += pV;
           capturedByWhite.push(cPD);
         } else {
           blackScore += pV;
+          blackMeta += pV;
           capturedByBlack.push(cPD);
         }
         updateCapturedDisplay();
@@ -2713,6 +2722,11 @@
           } else {
             gameState.gameStatus = "check";
             playSound("check");
+            if (gameState.currentPlayer === COLORS.WHITE) {
+              blackMeta += CHECK_REWARD;
+            } else {
+              whiteMeta += CHECK_REWARD;
+            }
           }
         } else {
           const lM = getAllLegalMoves(gameState.currentPlayer);
@@ -3155,6 +3169,10 @@
           gameState.currentPlayer === COLORS.WHITE ? "#eee" : "#aaa";
         document.getElementById("white-score").textContent = whiteScore;
         document.getElementById("black-score").textContent = blackScore;
+        const wm = document.getElementById("white-meta");
+        const bm = document.getElementById("black-meta");
+        if (wm) wm.textContent = whiteMeta;
+        if (bm) bm.textContent = blackMeta;
         const sS = document.getElementById("status");
         let sT = "";
         switch (gameState.gameStatus) {

--- a/refactored/index.html
+++ b/refactored/index.html
@@ -154,6 +154,8 @@
       <div><span id="turn-label">Turn:</span> <span id="turn">White</span></div>
       <div>White Material: <span id="white-score">0</span></div>
       <div>Black Material: <span id="black-score">0</span></div>
+      <div>White Meta: <span id="white-meta">0</span></div>
+      <div>Black Meta: <span id="black-meta">0</span></div>
       <div>Status: <span id="status">Waiting...</span></div>
     </div>
     <div id="move-log"></div>

--- a/refactored/js/game.js
+++ b/refactored/js/game.js
@@ -168,6 +168,7 @@ const PIECE_VALUES = {
 const CAPTURED_SCALE = 0.5;
 const CAPTURED_SPACING = VOXEL_SIZE * (CAPTURED_SCALE + 0.2);
 const AI_DELAY = 500;
+const CHECK_REWARD = 1;
 const STARSHIP_IMAGES = {
   [PIECE_TYPES.PAWN]: "../assets/starship/pieces/P.svg",
   [PIECE_TYPES.ROOK]: "../assets/starship/pieces/R.svg",
@@ -229,6 +230,8 @@ let capturedByWhite = [];
 let capturedByBlack = [];
 let whiteScore = 0;
 let blackScore = 0;
+let whiteMeta = 0;
+let blackMeta = 0;
 let capturedWhiteDisplayMeshes = [];
 let capturedBlackDisplayMeshes = [];
 let selectedPiece = null;
@@ -650,6 +653,8 @@ function setupBoardState() {
   capturedByBlack = [];
   whiteScore = 0;
   blackScore = 0;
+  whiteMeta = 0;
+  blackMeta = 0;
   capturedWhiteDisplayMeshes.forEach((m) => scene.remove(m));
   capturedBlackDisplayMeshes.forEach((m) => scene.remove(m));
   capturedWhiteDisplayMeshes = [];
@@ -2137,9 +2142,11 @@ function handleCapture(cPD, cPP, cP) {
   const pV = PIECE_VALUES[cPD.type] || 0;
   if (cP === COLORS.WHITE) {
     whiteScore += pV;
+    whiteMeta += pV;
     capturedByWhite.push(cPD);
   } else {
     blackScore += pV;
+    blackMeta += pV;
     capturedByBlack.push(cPD);
   }
   updateCapturedDisplay();
@@ -2211,6 +2218,11 @@ function updateGameStatusAndCheckEnd() {
     } else {
       gameState.gameStatus = "check";
       playSound("check");
+      if (gameState.currentPlayer === COLORS.WHITE) {
+        blackMeta += CHECK_REWARD;
+      } else {
+        whiteMeta += CHECK_REWARD;
+      }
     }
   } else {
     const lM = getAllLegalMoves(gameState.currentPlayer);
@@ -2292,6 +2304,10 @@ function updateInfoPanel() {
   tS.style.color = gameState.currentPlayer === COLORS.WHITE ? "#eee" : "#aaa";
   document.getElementById("white-score").textContent = whiteScore;
   document.getElementById("black-score").textContent = blackScore;
+  const wm = document.getElementById("white-meta");
+  const bm = document.getElementById("black-meta");
+  if (wm) wm.textContent = whiteMeta;
+  if (bm) bm.textContent = blackMeta;
   const sS = document.getElementById("status");
   let sT = "";
   switch (gameState.gameStatus) {


### PR DESCRIPTION
## Summary
- reward players for capturing pieces and giving check
- display meta scores in info panel for both versions

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68475853ed00832d8967cd17d2aa81a0