### PR TITLE
Increase player1 specular highlight

### DIFF
--- a/3dchess20.html
+++ b/3dchess20.html
@@ -457,8 +457,8 @@
         /* ... Materials ... */
         [COLORS.WHITE]: new THREE.MeshStandardMaterial({
           color: 0xdddddd,
-          roughness: 0.7,
-          metalness: 0.1,
+          roughness: 0.4,
+          metalness: 0.4,
         }),
         [COLORS.BLACK]: new THREE.MeshStandardMaterial({
           color: 0x333333,
@@ -467,8 +467,8 @@
         }),
         ROYAL_WHITE: new THREE.MeshStandardMaterial({
           color: 0xfff8e1,
-          roughness: 0.5,
-          metalness: 0.2,
+          roughness: 0.3,
+          metalness: 0.5,
         }),
         ROYAL_BLACK: new THREE.MeshStandardMaterial({
           color: 0x404050,
@@ -477,8 +477,8 @@
         }),
         ROYAL_BASE_WHITE: new THREE.MeshStandardMaterial({
           color: 0xc0c0c0,
-          roughness: 0.4,
-          metalness: 0.3,
+          roughness: 0.2,
+          metalness: 0.6,
         }),
         ROYAL_BASE_BLACK: new THREE.MeshStandardMaterial({
           color: 0x504040,

--- a/refactored/js/game.js
+++ b/refactored/js/game.js
@@ -14,8 +14,8 @@ const MATERIALS = {
   /* ... Materials ... */
   [COLORS.WHITE]: new THREE.MeshStandardMaterial({
     color: 0xdddddd,
-    roughness: 0.7,
-    metalness: 0.1,
+    roughness: 0.4,
+    metalness: 0.4,
   }),
   [COLORS.BLACK]: new THREE.MeshStandardMaterial({
     color: 0x333333,
@@ -24,8 +24,8 @@ const MATERIALS = {
   }),
   ROYAL_WHITE: new THREE.MeshStandardMaterial({
     color: 0xfff8e1,
-    roughness: 0.5,
-    metalness: 0.2,
+    roughness: 0.3,
+    metalness: 0.5,
   }),
   ROYAL_BLACK: new THREE.MeshStandardMaterial({
     color: 0x404050,
@@ -34,8 +34,8 @@ const MATERIALS = {
   }),
   ROYAL_BASE_WHITE: new THREE.MeshStandardMaterial({
     color: 0xc0c0c0,
-    roughness: 0.4,
-    metalness: 0.3,
+    roughness: 0.2,
+    metalness: 0.6,
   }),
   ROYAL_BASE_BLACK: new THREE.MeshStandardMaterial({
     color: 0x504040,


### PR DESCRIPTION
## Summary
- Increase shininess of Player 1 pieces by lowering roughness and boosting metalness for white materials
- Sync material updates in refactored game script

## Testing
- `node --check refactored/js/game.js`
- `apt-get update` *(fails: repository is not signed; unable to install browser for manual HTML check)*

------
https://chatgpt.com/codex/tasks/task_e_68a4ca1472ac832dad0486524b8bf2ed